### PR TITLE
fix: change README link to sapphire from klasa

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ yarn pm2:start
 
 **Framework links**
 
--   [Klasa's Website](https://klasa.js.org)
+-   [Sapphire's Website](https://sapphirejs.com/)
 
 <!-- Link Dump -->
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ yarn pm2:start
 
 **Framework links**
 
--   [Sapphire's Website](https://sapphirejs.com/)
+-   [Sapphire's Website](https://www.sapphirejs.dev/)
 
 <!-- Link Dump -->
 


### PR DESCRIPTION
Changed the framework link from Klasa to Sapphire which was missed during the framework update.